### PR TITLE
Set response header to a valid date in the past.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var cacheControl = function cacheControl(req, res,
     next) {
 
   // Support old browsers
-  res.setHeader('Expires', 0);
+  res.setHeader('Expires', 'Fri, 01 Jan 1990 00:00:00 GMT');
 
   // Support recent browsers
   res.setHeader('Cache-Control', 'no-store, ' +
@@ -33,3 +33,4 @@ var cacheControl = function cacheControl(req, res,
 };
 
 module.exports = cacheControl;
+


### PR DESCRIPTION
Change the response header from 'Expires=0' to 'Expires=Fri, 01 Jan 1990 00:00:00 GMT'

From: https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching_FAQ

"It is interesting to note that "Expires: 0" and "Pragma: no-cache" are technically invalid response headers. If none of these headers are present, then the expiration calculation is essentially the algorithm described in RFC 2616 section 13.2."
